### PR TITLE
fix(stirling): correct compress endpoint and params

### DIFF
--- a/wp-content/plugins/pdfmaster-processor/includes/class-stirling-api.php
+++ b/wp-content/plugins/pdfmaster-processor/includes/class-stirling-api.php
@@ -52,7 +52,8 @@ class StirlingApi
             return new WP_Error('file_not_found', __('File does not exist', 'pdfmaster-processor'));
         }
 
-        $url = $this->get_endpoint() . '/api/v1/general/compress-pdf';
+        // Correct endpoint per Stirling PDF OpenAPI (/v1/api-docs): /api/v1/misc/compress-pdf
+        $url = $this->get_endpoint() . '/api/v1/misc/compress-pdf';
 
         $boundary = wp_generate_password(24, false);
         $body = $this->build_multipart_body([
@@ -62,7 +63,12 @@ class StirlingApi
                 'mime'     => 'application/pdf',
             ],
         ], [
-            'compressionLevel' => '2',
+            // Align with OptimizePdfRequest schema
+            'optimizeLevel'      => '5',
+            'expectedOutputSize' => '25KB',
+            'linearize'          => 'false',
+            'normalize'          => 'false',
+            'grayscale'          => 'false',
         ], $boundary);
 
         $response = wp_remote_post($url, [


### PR DESCRIPTION
Droid-assisted\n\nFixes 404 on compress operation by aligning with Stirling-PDF OpenAPI:\n- Endpoint: /api/v1/misc/compress-pdf (instead of /api/v1/general/compress-pdf)\n- Send OptimizePdfRequest fields: optimizeLevel, expectedOutputSize, linearize, normalize, grayscale\n- Merge endpoint unchanged (/api/v1/general/merge-pdfs)\n\nQA:\n- Verified Docker + service up at http://localhost:8080 (status: UP)\n- Test page: http://localhost:10003/test-processor/\n- Posted via AJAX with nonce; received success and download URL\n\nAll checks: PHP lint OK. No other files changed.